### PR TITLE
Fixes #4: Include all needed batik parts in GMF

### DIFF
--- a/org.eclipse.gmf.runtime.thirdparty-feature/feature.xml
+++ b/org.eclipse.gmf.runtime.thirdparty-feature/feature.xml
@@ -34,14 +34,19 @@ SPDX-License-Identifier: EPL-2.0
       <import plugin="org.eclipse.osgi"/>
    </requires>
 
-   <plugin id="org.apache.batik.awt.util"   download-size="0" install-size="0" version="0.0.0" unpack="false"/>
    <plugin id="org.apache.batik.anim"       download-size="0" install-size="0" version="0.0.0" unpack="false"/>
+   <plugin id="org.apache.batik.awt.util"   download-size="0" install-size="0" version="0.0.0" unpack="false"/>
    <plugin id="org.apache.batik.bridge"     download-size="0" install-size="0" version="0.0.0" unpack="false"/>
+   <plugin id="org.apache.batik.codec"      download-size="0" install-size="0" version="0.0.0" unpack="false"/>
+   <plugin id="org.apache.batik.constants"  download-size="0" install-size="0" version="0.0.0" unpack="false"/>
    <plugin id="org.apache.batik.css"        download-size="0" install-size="0" version="0.0.0" unpack="false"/>
    <plugin id="org.apache.batik.dom"        download-size="0" install-size="0" version="0.0.0" unpack="false"/>
    <plugin id="org.apache.batik.dom.svg"    download-size="0" install-size="0" version="0.0.0" unpack="false"/>
+   <plugin id="org.apache.batik.ext"        download-size="0" install-size="0" version="0.0.0" unpack="false"/>
    <plugin id="org.apache.batik.gvt"        download-size="0" install-size="0" version="0.0.0" unpack="false"/>
+   <plugin id="org.apache.batik.i18n"       download-size="0" install-size="0" version="0.0.0" unpack="false"/>
    <plugin id="org.apache.batik.parser"     download-size="0" install-size="0" version="0.0.0" unpack="false"/>
+   <plugin id="org.apache.batik.script"     download-size="0" install-size="0" version="0.0.0" unpack="false"/>
    <plugin id="org.apache.batik.svggen"     download-size="0" install-size="0" version="0.0.0" unpack="false"/>
    <plugin id="org.apache.batik.transcoder" download-size="0" install-size="0" version="0.0.0" unpack="false"/>
    <plugin id="org.apache.batik.util"       download-size="0" install-size="0" version="0.0.0" unpack="false"/>

--- a/org.eclipse.gmf.runtime.thirdparty.source-feature/feature.xml
+++ b/org.eclipse.gmf.runtime.thirdparty.source-feature/feature.xml
@@ -30,14 +30,19 @@ SPDX-License-Identifier: EPL-2.0
       <update label="%updateSiteName" url="http://download.eclipse.org/modeling/gmp/gmf-runtime/updates/releases/"/>
    </url>
 
-   <plugin id="org.apache.batik.awt.util.source"   download-size="0" install-size="0" version="0.0.0" unpack="false"/>
    <plugin id="org.apache.batik.anim.source"       download-size="0" install-size="0" version="0.0.0" unpack="false"/>
+   <plugin id="org.apache.batik.awt.util.source"   download-size="0" install-size="0" version="0.0.0" unpack="false"/>
    <plugin id="org.apache.batik.bridge.source"     download-size="0" install-size="0" version="0.0.0" unpack="false"/>
+   <plugin id="org.apache.batik.codec.source"      download-size="0" install-size="0" version="0.0.0" unpack="false"/>
+   <plugin id="org.apache.batik.constants.source"  download-size="0" install-size="0" version="0.0.0" unpack="false"/>
    <plugin id="org.apache.batik.css.source"        download-size="0" install-size="0" version="0.0.0" unpack="false"/>
    <plugin id="org.apache.batik.dom.source"        download-size="0" install-size="0" version="0.0.0" unpack="false"/>
    <plugin id="org.apache.batik.dom.svg.source"    download-size="0" install-size="0" version="0.0.0" unpack="false"/>
+   <plugin id="org.apache.batik.ext.source"        download-size="0" install-size="0" version="0.0.0" unpack="false"/>
    <plugin id="org.apache.batik.gvt.source"        download-size="0" install-size="0" version="0.0.0" unpack="false"/>
+   <plugin id="org.apache.batik.i18n.source"       download-size="0" install-size="0" version="0.0.0" unpack="false"/>
    <plugin id="org.apache.batik.parser.source"     download-size="0" install-size="0" version="0.0.0" unpack="false"/>
+   <plugin id="org.apache.batik.script.source"     download-size="0" install-size="0" version="0.0.0" unpack="false"/>
    <plugin id="org.apache.batik.svggen.source"     download-size="0" install-size="0" version="0.0.0" unpack="false"/>
    <plugin id="org.apache.batik.transcoder.source" download-size="0" install-size="0" version="0.0.0" unpack="false"/>
    <plugin id="org.apache.batik.util.source"       download-size="0" install-size="0" version="0.0.0" unpack="false"/>


### PR DESCRIPTION
Note that some of these bundles were being pulled in from Orbit
directly on simrel, some from eclipse platform.