### PR TITLE
Adapt to upcoming API changes in GEF Classic

### DIFF
--- a/bundles/org.eclipse.gmf.runtime.diagram.ui/src/org/eclipse/gmf/runtime/diagram/ui/editpolicies/CanonicalConnectionEditPolicy.java
+++ b/bundles/org.eclipse.gmf.runtime.diagram.ui/src/org/eclipse/gmf/runtime/diagram/ui/editpolicies/CanonicalConnectionEditPolicy.java
@@ -101,7 +101,7 @@ public abstract class CanonicalConnectionEditPolicy
 	 */
 	protected void refreshOnActivate() {
 		// need to activate editpart children before invoking the canonical refresh
-		List<EditPart> c = getHost().getChildren();
+		List<? extends EditPart> c = getHost().getChildren();
 		for (int i = 0; i < c.size(); i++) {
 			c.get(i).activate();
 		}

--- a/bundles/org.eclipse.gmf.runtime.diagram.ui/src/org/eclipse/gmf/runtime/diagram/ui/editpolicies/ContainerEditPolicy.java
+++ b/bundles/org.eclipse.gmf.runtime.diagram.ui/src/org/eclipse/gmf/runtime/diagram/ui/editpolicies/ContainerEditPolicy.java
@@ -279,11 +279,14 @@ public class ContainerEditPolicy
         String layoutDesc = request.getLayoutType() != null ? request.getLayoutType() : LayoutType.DEFAULT;
         
         boolean offsetFromBoundingBox = false;
-        List<IGraphicalEditPart> editparts = new ArrayList<IGraphicalEditPart>();
+        List<IGraphicalEditPart> editparts = new ArrayList<>();
         
         if ( (ActionIds.ACTION_ARRANGE_ALL.equals(request.getType())) || 
              (ActionIds.ACTION_TOOLBAR_ARRANGE_ALL.equals(request.getType()))) {
-            editparts = ((IGraphicalEditPart)getHost()).getChildren();          
+            editparts = ((IGraphicalEditPart) getHost()).getChildren().stream()
+            				.filter(IGraphicalEditPart.class::isInstance)
+            				.map(IGraphicalEditPart.class::cast)
+            				.toList();
             request.setPartsToArrange(editparts);
         }
         if ( (ActionIds.ACTION_ARRANGE_SELECTION.equals(request.getType())) ||


### PR DESCRIPTION
GraphicalEditPart.getChildren() now returns a List<? extends GraphicalEditPart>

See-also: https://github.com/eclipse/gef-classic/pull/212
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
