### PR TITLE
Bug 582119 - [Memory] Memory leaks in GMF runtime

### DIFF
--- a/bundles/org.eclipse.gmf.runtime.diagram.ui.resources.editor/src/org/eclipse/gmf/runtime/diagram/ui/resources/editor/parts/DiagramDocumentEditor.java
+++ b/bundles/org.eclipse.gmf.runtime.diagram.ui.resources.editor/src/org/eclipse/gmf/runtime/diagram/ui/resources/editor/parts/DiagramDocumentEditor.java
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2005, 2013 IBM Corporation and others.
+ * Copyright (c) 2005, 2013, 2023 IBM Corporation and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -7,7 +7,8 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *    IBM Corporation - initial API and implementation 
+ *    IBM Corporation - initial API and implementation
+ *    Ansgar Radermacher - contribution for bug 582119
  ****************************************************************************/
 
 package org.eclipse.gmf.runtime.diagram.ui.resources.editor.parts;
@@ -163,9 +164,18 @@ public class DiagramDocumentEditor
 	 * @see org.eclipse.ui.part.WorkbenchPart#setSite(org.eclipse.ui.IWorkbenchPartSite)
 	 */
 	protected final void setSite(IWorkbenchPartSite site) {
+		boolean siteChanged = site != getSite();
 		super.setSite(site);
-		fActivationListener= new ActivationListener(site.getWorkbenchWindow().getPartService());
-		fActivationListener.activate();
+		if (siteChanged && fActivationListener != null) {
+			// dispose old activation listener, if workbench site has changed
+			fActivationListener.deactivate();
+			fActivationListener.dispose();
+			fActivationListener = null;
+		}
+		if (fActivationListener == null) {
+			fActivationListener = new ActivationListener(site.getWorkbenchWindow().getPartService());
+			fActivationListener.activate();
+		}
 	}
 
 	/*

--- a/bundles/org.eclipse.gmf.runtime.diagram.ui/src/org/eclipse/gmf/runtime/diagram/ui/parts/DiagramEditor.java
+++ b/bundles/org.eclipse.gmf.runtime.diagram.ui/src/org/eclipse/gmf/runtime/diagram/ui/parts/DiagramEditor.java
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2002, 2009 IBM Corporation and others.
+ * Copyright (c) 2002, 2009, 2023 IBM Corporation and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -9,6 +9,7 @@
  * Contributors:
  *    IBM Corporation - initial API and implementation 
  *    Dmitry Stadnik (Borland) - contribution for bugzilla 136582
+ *    Ansgar Radermacher - contribution for bug 582119
  ****************************************************************************/
 
 package org.eclipse.gmf.runtime.diagram.ui.parts;
@@ -172,6 +173,8 @@ public abstract class DiagramEditor
      */
     protected PreferenceStore workspaceViewerPreferenceStore = null;
 
+    private KeyHandler viewerKeyHandler;
+    
     /**
      * A diagram outline page
      */
@@ -709,6 +712,13 @@ public abstract class DiagramEditor
                 disableUpdateHistoryListener);
         }
         
+        if (viewerKeyHandler != null) {
+        	viewerKeyHandler.setParent(null);
+        	getDiagramGraphicalViewer().setKeyHandler(null);
+        	viewerKeyHandler = null;
+        }
+        keyHandler = null;
+      
         super.dispose();
     }
 
@@ -849,7 +859,7 @@ public abstract class DiagramEditor
         viewer.setContextMenu(provider);
         getSite().registerContextMenu(ActionIds.DIAGRAM_EDITOR_CONTEXT_MENU,
             provider, viewer);
-        KeyHandler viewerKeyHandler = new DiagramGraphicalViewerKeyHandler(viewer)
+        viewerKeyHandler = new DiagramGraphicalViewerKeyHandler(viewer)
             .setParent(getKeyHandler());
         viewer.setKeyHandler(new DirectEditKeyHandler(viewer)
             .setParent(viewerKeyHandler));

--- a/bundles/org.eclipse.gmf.runtime.diagram.ui/src/org/eclipse/gmf/runtime/diagram/ui/parts/DiagramEditorWithFlyOutPalette.java
+++ b/bundles/org.eclipse.gmf.runtime.diagram.ui/src/org/eclipse/gmf/runtime/diagram/ui/parts/DiagramEditorWithFlyOutPalette.java
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2002, 2008 IBM Corporation and others.
+ * Copyright (c) 2002, 2008, 2023 IBM Corporation and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -7,7 +7,8 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *    IBM Corporation - initial API and implementation 
+ *    IBM Corporation - initial API and implementation
+ *    Ansgar Radermacher - contribution for bug xxxx 
  ****************************************************************************/
 
 package org.eclipse.gmf.runtime.diagram.ui.parts;
@@ -645,4 +646,20 @@ public abstract class DiagramEditorWithFlyOutPalette
         return new PaletteCustomizerEx(getPreferenceStore());
     }
 
+    /**
+     * Dispose splitter
+     */
+    @Override
+	public void dispose() {
+		if (splitter != null) {
+			splitter.setExternalViewer(null);
+			splitter.dispose();
+			splitter = null;
+		}
+		if (page != null) {
+			page.dispose();
+			page = null;
+		}
+		super.dispose();
+	}
 }


### PR DESCRIPTION
DiagramDocumentEditor: dispose existing activation listener, if site is different. Don't create a new if there is an existing with the same workbench site

DigramEditor: dispose registered keyHandler

DiagramEditorWithFlyOutPalette: dispose splitter and palette-page