### PR TITLE
[33] Increase the precision in edge segments computation

### DIFF
--- a/bundles/org.eclipse.gmf.runtime.draw2d.ui/src/org/eclipse/gmf/runtime/draw2d/ui/internal/routers/RectilinearRouter.java
+++ b/bundles/org.eclipse.gmf.runtime.draw2d.ui/src/org/eclipse/gmf/runtime/draw2d/ui/internal/routers/RectilinearRouter.java
@@ -471,8 +471,9 @@ public class RectilinearRouter extends ObliqueRouter implements OrthogonalRouter
     		Dimension offsetDim = offStart.getDifference(offEnd).scale(0.5);
     		offStart.translate(getTranslationValue(sourceAnchorRelativeLocation, Math.abs(offsetDim.width), Math.abs(offsetDim.height)));
     		offEnd.translate(getTranslationValue(targetAnchorRelativeLocation, Math.abs(offsetDim.width), Math.abs(offsetDim.height)));
-    		line.insertPoint(offStart, 1);
-    		line.insertPoint(offEnd, 2);
+    		// use Math.round because insertPoint takes the integer x,y of the precisePoint. The consequence is a potential error of one pixel
+    		line.insertPoint(new Point((int) Math.round(offStart.preciseX()), (int) Math.round(offStart.preciseY())), 1);
+    		line.insertPoint(new Point((int) Math.round(offEnd.preciseX()), (int) Math.round(offEnd.preciseY())), 2);
     		offSourceDirection = getOffShapeDirection(sourceAnchorRelativeLocation);
     		offTargetDirection = getOffShapeDirection(targetAnchorRelativeLocation);
     	} else {

--- a/bundles/org.eclipse.gmf.runtime.draw2d.ui/src/org/eclipse/gmf/runtime/draw2d/ui/internal/routers/RouterHelper.java
+++ b/bundles/org.eclipse.gmf.runtime.draw2d.ui/src/org/eclipse/gmf/runtime/draw2d/ui/internal/routers/RouterHelper.java
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2006, 2008 IBM Corporation and others.
+ * Copyright (c) 2006, 2023 IBM Corporation and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -517,8 +517,9 @@ class RouterHelper {
         conn.translateToRelative(sourceAnchorPoint);
         conn.translateToRelative(targetAnchorPoint);
         
-        newLine.setPoint(sourceAnchorPoint,0);
-        newLine.setPoint(targetAnchorPoint,newLine.size() - 1);
+        // use Math.round because insertPoint takes the integer x,y of the precisePoint. The consequence is a potential error of one pixel
+        newLine.setPoint(new Point((int) Math.round(sourceAnchorPoint.preciseX()), (int) Math.round(sourceAnchorPoint.preciseY())),0);
+        newLine.setPoint(new Point((int) Math.round(targetAnchorPoint.preciseX()), (int) Math.round(targetAnchorPoint.preciseY())),newLine.size() - 1);
     }
 
     private final static int ROUTER_OBSTRUCTION_BUFFER = 12;


### PR DESCRIPTION
Depending on the zoom, the bendpoints may slightly differ. While zooming, the precise point may pass from 50,999 to 51,001 and that imply that the PointList will contain 50 or 51.

One known consequence:
With a rectilinear edge(horizontal or vertical segments), the vector used to display the edge label is expressed in an orthonormal frame that depends of the orientation of the segment that contains the anchor point. So if the anchor point is at the limit of two segments, when changing the zoom, the segment computation must not vary of one pixel otherwise the edge label is not displayed at the same location.

The fix changes how the bendpoints are computed. It leverages precise points to get a round value instead of casting into integer (which takes the nearest lower integer) The fix is related to Router classes but we could imagine to do the changes inside PointList class in methods setPoint(Point pt, int index) and addPoint(Point p). Nevertheless, the change in PointList is very impacting.

Bug: https://github.com/eclipse/gmf-runtime/issues/33