### PR TITLE
[36] Remove the ActionMenuManager dispose call when menu is disposed

### DIFF
--- a/bundles/org.eclipse.gmf.runtime.common.ui/src/org/eclipse/gmf/runtime/common/ui/action/ActionMenuManager.java
+++ b/bundles/org.eclipse.gmf.runtime.common.ui/src/org/eclipse/gmf/runtime/common/ui/action/ActionMenuManager.java
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2002, 2008 IBM Corporation and others.
+ * Copyright (c) 2002, 2023 IBM Corporation and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -124,7 +124,6 @@ public class ActionMenuManager extends MenuManager {
                 menu = null;
             }
             super.dispose();
-            ActionMenuManager.this.dispose();
         }
 
         /**


### PR DESCRIPTION
The dispose of ActionMenuManager should not be call when its menu is disposed.

Bug: https://github.com/eclipse/gmf-runtime/issues/36