### PR TITLE
Adapt ObliqueRouter to GEF Classic API changes

### DIFF
--- a/bundles/org.eclipse.gmf.runtime.draw2d.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.gmf.runtime.draw2d.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gmf.runtime.draw2d.ui
-Bundle-Version: 1.10.1.qualifier
+Bundle-Version: 1.10.2.qualifier
 Bundle-Activator: org.eclipse.gmf.runtime.draw2d.ui.internal.Draw2dPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.gmf.runtime.draw2d.ui/pom.xml
+++ b/bundles/org.eclipse.gmf.runtime.draw2d.ui/pom.xml
@@ -10,6 +10,6 @@
   </parent>
   <groupId>org.eclipse.gmf.runtime.draw2d.ui</groupId>
   <artifactId>org.eclipse.gmf.runtime.draw2d.ui</artifactId>
-  <version>1.10.1-SNAPSHOT</version>
+  <version>1.10.2-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.gmf.runtime.draw2d.ui/src/org/eclipse/gmf/runtime/draw2d/ui/internal/routers/ObliqueRouter.java
+++ b/bundles/org.eclipse.gmf.runtime.draw2d.ui/src/org/eclipse/gmf/runtime/draw2d/ui/internal/routers/ObliqueRouter.java
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2002, 2010, 2023 IBM Corporation and others.
+ * Copyright (c) 2002, 2010, 2024 IBM Corporation and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -294,7 +294,7 @@ public class ObliqueRouter extends BendpointConnectionRouter {
 					// therefore causing routing to be done again)
 					spcr.setIgnoreInvalidate(true);
 					
-					List<Path> allPaths = spcr.getPathsAfterRouting();
+					List<? extends Path> allPaths = spcr.getPathsAfterRouting();
 					if (allPaths != null && allPaths.size() > 0) {
 						routed = true;
 						IFigure container = helper.getSourceContainer(conn);


### PR DESCRIPTION
See https://github.com/eclipse/gef-classic/commit/4635985b7045db7bd80758387c7c360aa7eda305#diff-3ced516b4ce648edea25ebf465cd7aff961fa35bd1c2d0eb1d8d05f2a9f607e9R304

Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
