### PR TITLE
[56] ConnectionEditPart never release notational listeners

### DIFF
--- a/bundles/org.eclipse.gmf.runtime.diagram.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.gmf.runtime.diagram.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gmf.runtime.diagram.ui; singleton:=true
-Bundle-Version: 1.10.1.qualifier
+Bundle-Version: 1.10.2.qualifier
 Bundle-Activator: org.eclipse.gmf.runtime.diagram.ui.internal.DiagramUIPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.gmf.runtime.diagram.ui/pom.xml
+++ b/bundles/org.eclipse.gmf.runtime.diagram.ui/pom.xml
@@ -10,6 +10,6 @@
   </parent>
   <groupId>org.eclipse.gmf.runtime.diagram.ui</groupId>
   <artifactId>org.eclipse.gmf.runtime.diagram.ui</artifactId>
-  <version>1.10.1-SNAPSHOT</version>
+  <version>1.10.2-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.gmf.runtime.diagram.ui/src/org/eclipse/gmf/runtime/diagram/ui/editparts/ConnectionEditPart.java
+++ b/bundles/org.eclipse.gmf.runtime.diagram.ui/src/org/eclipse/gmf/runtime/diagram/ui/editparts/ConnectionEditPart.java
@@ -382,6 +382,7 @@ abstract public class ConnectionEditPart
 	   
         boolean wasActive = isActive();
         super.deactivate();
+		removeNotationalListeners();
         if (listenerFilters != null && wasActive != isActive()) {
             for (Iterator i = listenerFilters.keySet().iterator(); i.hasNext();) {
                 Object[] obj = (Object[]) listenerFilters.get(i.next());


### PR DESCRIPTION
It seems that org.eclipse.gmf.runtime.diagram.ui.editparts.ConnectionEditPart never call the removeNotationalListeners() method. It is a part of a memory leak.

Bug #56
Signed-off-by: Pauline DEVILLE <pauline.deville@cea.fr>