### PR TITLE
[releng] Update Apache Commons Logging in canary target platform

### DIFF
--- a/releng/org.eclipse.gmf.runtime.target/canary.target
+++ b/releng/org.eclipse.gmf.runtime.target/canary.target
@@ -67,7 +67,7 @@
       <unit id="org.apache.xmlgraphics" version="2.9.0.v20230916-1600" />
       <unit id="org.apache.xmlgraphics.source" version="2.9.0.v20230916-1600" />
       <unit id="org.apache.commons.commons-io" version="2.16.1"/>
-      <unit id="org.apache.commons.commons-logging" version="1.3.1"/>
+      <unit id="org.apache.commons.commons-logging" version="1.3.2"/>
       <unit id="org.hamcrest" version="2.2.0"/>
       <unit id="org.eclipse.orbit.xml-apis-ext" version="1.0.0.v20230923-0644"/>
       <repository id="Orbit-latest-I" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly"/>


### PR DESCRIPTION
Orbit now includes Apache Commons Logging 1.3.2 instead of 1.3.1.

Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
