### PR TITLE
Remove references to deprecated ZoomListener

### DIFF
--- a/bundles/org.eclipse.gmf.runtime.diagram.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.gmf.runtime.diagram.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gmf.runtime.diagram.ui; singleton:=true
-Bundle-Version: 1.10.3.qualifier
+Bundle-Version: 1.11.0.qualifier
 Bundle-Activator: org.eclipse.gmf.runtime.diagram.ui.internal.DiagramUIPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
@@ -288,8 +288,8 @@ Export-Package: org.eclipse.gmf.runtime.diagram.ui,
 Require-Bundle: org.eclipse.ui.views;bundle-version="[3.3.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.5.0,4.0.0)",
- org.eclipse.draw2d;bundle-version="[3.5.0,4.0.0)",
- org.eclipse.gef;bundle-version="[3.5.0,4.0.0)";visibility:=reexport,
+ org.eclipse.draw2d;bundle-version="[3.13.0,4.0.0)",
+ org.eclipse.gef;bundle-version="[3.13.0,4.0.0)";visibility:=reexport,
  org.eclipse.core.runtime;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.gmf.runtime.emf.core;bundle-version="[1.2.0,2.0.0)";visibility:=reexport,
  org.eclipse.gmf.runtime.emf.commands.core;bundle-version="[1.2.0,2.0.0)",

--- a/bundles/org.eclipse.gmf.runtime.diagram.ui/pom.xml
+++ b/bundles/org.eclipse.gmf.runtime.diagram.ui/pom.xml
@@ -10,6 +10,6 @@
   </parent>
   <groupId>org.eclipse.gmf.runtime.diagram.ui</groupId>
   <artifactId>org.eclipse.gmf.runtime.diagram.ui</artifactId>
-  <version>1.10.3-SNAPSHOT</version>
+  <version>1.11.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.gmf.runtime.diagram.ui/src/org/eclipse/gmf/runtime/diagram/ui/editparts/DiagramRootEditPart.java
+++ b/bundles/org.eclipse.gmf.runtime.diagram.ui/src/org/eclipse/gmf/runtime/diagram/ui/editparts/DiagramRootEditPart.java
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2002, 2009 IBM Corporation and others.
+ * Copyright (c) 2002, 2025 IBM Corporation and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -24,12 +24,12 @@ import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.draw2d.geometry.Translatable;
+import org.eclipse.draw2d.zoom.ZoomListener;
 import org.eclipse.gef.Request;
 import org.eclipse.gef.SnapToGeometry;
 import org.eclipse.gef.SnapToGrid;
 import org.eclipse.gef.editparts.GridLayer;
 import org.eclipse.gef.editparts.ScalableFreeformRootEditPart;
-import org.eclipse.gef.editparts.ZoomListener;
 import org.eclipse.gef.editparts.ZoomManager;
 import org.eclipse.gef.rulers.RulerProvider;
 import org.eclipse.gmf.runtime.common.core.util.Log;
@@ -193,7 +193,7 @@ public class DiagramRootEditPart
 
 		/* 
 		 * (non-Javadoc)
-		 * @see org.eclipse.gef.editparts.ZoomListener#zoomChanged(double)
+		 * @see ZoomListener#zoomChanged(double)
 		 */
 		public void zoomChanged(double zoom) {
 			ScaledGraphics.resetFontCache();

--- a/bundles/org.eclipse.gmf.runtime.diagram.ui/src/org/eclipse/gmf/runtime/diagram/ui/internal/actions/ZoomContributionItem.java
+++ b/bundles/org.eclipse.gmf.runtime.diagram.ui/src/org/eclipse/gmf/runtime/diagram/ui/internal/actions/ZoomContributionItem.java
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2002, 2009 IBM Corporation and others.
+ * Copyright (c) 2002, 2025 IBM Corporation and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -20,9 +20,9 @@ import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.Viewport;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
+import org.eclipse.draw2d.zoom.ZoomListener;
 import org.eclipse.gef.GraphicalEditPart;
 import org.eclipse.gef.Request;
-import org.eclipse.gef.editparts.ZoomListener;
 import org.eclipse.gef.editparts.ZoomManager;
 import org.eclipse.gmf.runtime.diagram.ui.actions.ActionIds;
 import org.eclipse.gmf.runtime.diagram.ui.internal.l10n.DiagramUIPluginImages;
@@ -173,7 +173,7 @@ public class ZoomContributionItem extends CustomContributionItem implements Zoom
 	}
 
 	/**
-	 * @see org.eclipse.gef.editparts.ZoomListener#zoomChanged(double)
+	 * @see ZoomListener#zoomChanged(double)
 	 */
 	public void zoomChanged(double zoom) {
 		update();

--- a/bundles/org.eclipse.gmf.runtime.gef.ui/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.gmf.runtime.gef.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.gmf.runtime.gef.ui
-Bundle-Version: 1.8.1.qualifier
+Bundle-Version: 1.9.0.qualifier
 Bundle-Activator: org.eclipse.gmf.runtime.gef.ui.internal.GefPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin
@@ -20,8 +20,8 @@ Export-Package: org.eclipse.gmf.runtime.gef.ui.figures,
  org.eclipse.gmf.runtime.gef.ui.internal.tools;x-friends:="org.eclipse.gmf.tests.runtime.diagram.ui,org.eclipse.gmf.tests.runtime.gef.ui,org.eclipse.gmf.runtime.diagram.ui,org.eclipse.gmf.runtime.diagram.ui.render,org.eclipse.gmf.runtime.diagram.ui.providers",
  org.eclipse.gmf.runtime.gef.ui.palette.customize
 Require-Bundle: org.eclipse.ui;bundle-version="[3.5.0,4.0.0)",
- org.eclipse.draw2d;bundle-version="[3.6.0,4.0.0)";visibility:=reexport,
- org.eclipse.gef;bundle-version="[3.5.0,4.0.0)",
+ org.eclipse.draw2d;bundle-version="[3.13.0,4.0.0)";visibility:=reexport,
+ org.eclipse.gef;bundle-version="[3.13.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.gmf.runtime.common.core;bundle-version="[1.2.0,2.0.0)",
  org.eclipse.gmf.runtime.common.ui;bundle-version="[1.2.0,2.0.0)",

--- a/bundles/org.eclipse.gmf.runtime.gef.ui/pom.xml
+++ b/bundles/org.eclipse.gmf.runtime.gef.ui/pom.xml
@@ -10,6 +10,6 @@
   </parent>
   <groupId>org.eclipse.gmf.runtime.gef.ui</groupId>
   <artifactId>org.eclipse.gmf.runtime.gef.ui</artifactId>
-  <version>1.8.1-SNAPSHOT</version>
+  <version>1.9.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/bundles/org.eclipse.gmf.runtime.gef.ui/src/org/eclipse/gmf/runtime/gef/ui/internal/editparts/AnimatableZoomManager.java
+++ b/bundles/org.eclipse.gmf.runtime.gef.ui/src/org/eclipse/gmf/runtime/gef/ui/internal/editparts/AnimatableZoomManager.java
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2004 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -21,7 +21,7 @@ import org.eclipse.draw2d.Viewport;
 import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
-import org.eclipse.gef.editparts.ZoomListener;
+import org.eclipse.draw2d.zoom.ZoomListener;
 import org.eclipse.gef.editparts.ZoomManager;
 import org.eclipse.gmf.runtime.draw2d.ui.geometry.LineSeg;
 import org.eclipse.gmf.runtime.draw2d.ui.internal.figures.AnimationModel;

--- a/bundles/org.eclipse.gmf.runtime.gef.ui/src/org/eclipse/gmf/runtime/gef/ui/internal/editparts/AnimatedZoomListener.java
+++ b/bundles/org.eclipse.gmf.runtime.gef.ui/src/org/eclipse/gmf/runtime/gef/ui/internal/editparts/AnimatedZoomListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -12,7 +12,7 @@
 
 package org.eclipse.gmf.runtime.gef.ui.internal.editparts;
 
-import org.eclipse.gef.editparts.ZoomListener;
+import org.eclipse.draw2d.zoom.ZoomListener;
 
 /**
  * Listens to animated zoom changes.


### PR DESCRIPTION
The GEF ZoomListener has been deprecated for removal in 2022 and removed in the 3.23 release, with the Draw2D ZoomListener being the drop-in replacement.

Contributes to
https://github.com/eclipse-gmf-runtime/gmf-runtime/issues/13