### PR TITLE
[90] Fix cursor initialization when using fractional scaling

### DIFF
--- a/bundles/org.eclipse.gmf.runtime.gef.ui/src/org/eclipse/gmf/runtime/gef/ui/internal/l10n/Cursors.java
+++ b/bundles/org.eclipse.gmf.runtime.gef.ui/src/org/eclipse/gmf/runtime/gef/ui/internal/l10n/Cursors.java
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2002, 2003 IBM Corporation and others.
+ * Copyright (c) 2002, 2025 IBM Corporation and others.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -12,14 +12,18 @@
 
 package org.eclipse.gmf.runtime.gef.ui.internal.l10n;
 
-import org.eclipse.swt.graphics.Cursor;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.swt.graphics.Cursor;
+import org.eclipse.swt.graphics.Device;
+import org.eclipse.swt.graphics.ImageDataProvider;
 
 /**
- * This is class that stores a series of globally accessible cursors.
+ * Stores a series of globally accessible cursors.
  * 
  * @author sshaw
- *
  */
 public class Cursors {
 
@@ -30,30 +34,27 @@ public class Cursors {
     public static final Cursor CURSOR_SEG_ADD;
     
     /**
-     * Constant define for a cusor used to move an existing line segment
+     * Constant define for a cursor used to move an existing line segment
      */
     public static final Cursor CURSOR_SEG_MOVE;
-    
-    private static int deviceZoom = -1;
 
     static {
-		CURSOR_SEG_ADD = new Cursor(null, GefUIPluginImages.DESC_SEG_ADD.getImageData(getDeviceZoom()), 0, 0);
-		CURSOR_SEG_MOVE = new Cursor(null, GefUIPluginImages.DESC_SEG_MOVE.getImageData(getDeviceZoom()), 0, 0);
+		CURSOR_SEG_ADD = createCursor(GefUIPluginImages.DESC_SEG_ADD, 0, 0);
+		CURSOR_SEG_MOVE = createCursor(GefUIPluginImages.DESC_SEG_MOVE, 0, 0);
 	}
     
-    // Taken from org.eclipse.gef.SharedCursors.java
-	private static int getDeviceZoom() {
-		if (deviceZoom == -1) {
-			deviceZoom = 100; // default value
-			String deviceZoomProperty = System.getProperty("org.eclipse.swt.internal.deviceZoom"); //$NON-NLS-1$
-			if (deviceZoomProperty != null) {
-				try {
-					deviceZoom = Integer.parseInt(deviceZoomProperty);
-				} catch (NumberFormatException ex) {
-					// if the property can not be parsed we keep the default 100% zoom level
-				}
-			}
+	// Taken from org.eclipse.gef.internal.InternalGEFPlugin.java
+    // https://github.com/eclipse-gef/gef-classic/blob/467992a631d37b3a5268765ad87bcae8425a9d21/org.eclipse.gef/src/org/eclipse/gef/internal/InternalGEFPlugin.java#L127
+	private static Cursor createCursor(ImageDescriptor source, int hotspotX, int hotspotY) {
+		try {
+			Constructor<Cursor> ctor = Cursor.class.getConstructor(Device.class, ImageDataProvider.class, int.class,
+					int.class);
+			return ctor.newInstance(null, (ImageDataProvider) source::getImageData, hotspotX, hotspotY);
+		} catch (NoSuchMethodException e) {
+			// SWT version < 3.131.0 (no ImageDataProvider-based constructor)
+			return new Cursor(null, source.getImageData(100), hotspotX, hotspotY); // older constructor
+		} catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+			throw new RuntimeException("Failed to instantiate Cursor", e); //$NON-NLS-1$
 		}
-		return deviceZoom;
 	}
 }


### PR DESCRIPTION
[90] Fix cursor initialization when using fractional scaling

Recent Eclipse version support fractional zoom level as opposed to 100% or 200% zoom. Because no icons exist for those levels, an IllegalArgumentException is thrown when trying to create the corresponding cursors.

In order to solve this, one has to consider the following cases:

1) Newer SWT versions provide a Cursor constructor that accepts an ImageDataProvider. This constructor always creates image data matching the device zoom.

2) Win32: Older SWT versions automatically upscale the image data to match the device zoom. Therefore the original image data must be at 100% zoom.

3) On other operating systems, the image data should be pre-scaled, as no further scaling is done by SWT.