### PR TITLE
[87] Switch to Apache Batik 1.19

### DIFF
--- a/releng/org.eclipse.gmf.runtime.target/2022-09.target
+++ b/releng/org.eclipse.gmf.runtime.target/2022-09.target
@@ -8,45 +8,45 @@
       <repository id="Eclipse-Shared-License" location="https://download.eclipse.org/cbi/updates/license"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.apache.batik.anim" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.anim.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.xmlgraphics" version="2.10.0.v20241009-1200" />
-      <unit id="org.apache.xmlgraphics.source" version="2.10.0.v20241009-1200" />
-      <repository id="Orbit-4.35.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.35.0"/>
+      <unit id="org.apache.batik.anim" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.anim.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.xmlgraphics" version="2.11.0.v20250506-1400" />
+      <unit id="org.apache.xmlgraphics.source" version="2.11.0.v20250506-1400" />
+      <repository id="Orbit-4.36.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
     </location>
     <!-- End common locations -->
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/releng/org.eclipse.gmf.runtime.target/2022-12.target
+++ b/releng/org.eclipse.gmf.runtime.target/2022-12.target
@@ -8,45 +8,45 @@
       <repository id="Eclipse-Shared-License" location="https://download.eclipse.org/cbi/updates/license"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.apache.batik.anim" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.anim.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.xmlgraphics" version="2.10.0.v20241009-1200" />
-      <unit id="org.apache.xmlgraphics.source" version="2.10.0.v20241009-1200" />
-      <repository id="Orbit-4.35.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.35.0"/>
+      <unit id="org.apache.batik.anim" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.anim.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.xmlgraphics" version="2.11.0.v20250506-1400" />
+      <unit id="org.apache.xmlgraphics.source" version="2.11.0.v20250506-1400" />
+      <repository id="Orbit-4.36.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
     </location>
     <!-- End common locations -->
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/releng/org.eclipse.gmf.runtime.target/2023-03.target
+++ b/releng/org.eclipse.gmf.runtime.target/2023-03.target
@@ -8,45 +8,45 @@
       <repository id="Eclipse-Shared-License" location="https://download.eclipse.org/cbi/updates/license"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.apache.batik.anim" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.anim.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.xmlgraphics" version="2.10.0.v20241009-1200" />
-      <unit id="org.apache.xmlgraphics.source" version="2.10.0.v20241009-1200" />
-      <repository id="Orbit-4.35.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.35.0"/>
+      <unit id="org.apache.batik.anim" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.anim.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.xmlgraphics" version="2.11.0.v20250506-1400" />
+      <unit id="org.apache.xmlgraphics.source" version="2.11.0.v20250506-1400" />
+      <repository id="Orbit-4.36.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
     </location>
     <!-- End common locations -->
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/releng/org.eclipse.gmf.runtime.target/2023-06.target
+++ b/releng/org.eclipse.gmf.runtime.target/2023-06.target
@@ -8,45 +8,45 @@
       <repository id="Eclipse-Shared-License" location="https://download.eclipse.org/cbi/updates/license"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.apache.batik.anim" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.anim.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.xmlgraphics" version="2.10.0.v20241009-1200" />
-      <unit id="org.apache.xmlgraphics.source" version="2.10.0.v20241009-1200" />
-      <repository id="Orbit-4.35.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.35.0"/>
+      <unit id="org.apache.batik.anim" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.anim.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.xmlgraphics" version="2.11.0.v20250506-1400" />
+      <unit id="org.apache.xmlgraphics.source" version="2.11.0.v20250506-1400" />
+      <repository id="Orbit-4.36.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
     </location>
     <!-- End common locations -->
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/releng/org.eclipse.gmf.runtime.target/2023-09.target
+++ b/releng/org.eclipse.gmf.runtime.target/2023-09.target
@@ -8,45 +8,45 @@
       <repository id="Eclipse-Shared-License" location="https://download.eclipse.org/cbi/updates/license"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.apache.batik.anim" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.anim.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.xmlgraphics" version="2.10.0.v20241009-1200" />
-      <unit id="org.apache.xmlgraphics.source" version="2.10.0.v20241009-1200" />
-      <repository id="Orbit-4.35.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.35.0"/>
+      <unit id="org.apache.batik.anim" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.anim.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.xmlgraphics" version="2.11.0.v20250506-1400" />
+      <unit id="org.apache.xmlgraphics.source" version="2.11.0.v20250506-1400" />
+      <repository id="Orbit-4.36.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
     </location>
     <!-- End common locations -->
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/releng/org.eclipse.gmf.runtime.target/2023-12.target
+++ b/releng/org.eclipse.gmf.runtime.target/2023-12.target
@@ -8,45 +8,45 @@
       <repository id="Eclipse-Shared-License" location="https://download.eclipse.org/cbi/updates/license"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.apache.batik.anim" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.anim.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.xmlgraphics" version="2.10.0.v20241009-1200" />
-      <unit id="org.apache.xmlgraphics.source" version="2.10.0.v20241009-1200" />
-      <repository id="Orbit-4.35.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.35.0"/>
+      <unit id="org.apache.batik.anim" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.anim.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.xmlgraphics" version="2.11.0.v20250506-1400" />
+      <unit id="org.apache.xmlgraphics.source" version="2.11.0.v20250506-1400" />
+      <repository id="Orbit-4.36.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
     </location>
     <!-- End common locations -->
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/releng/org.eclipse.gmf.runtime.target/2024-03.target
+++ b/releng/org.eclipse.gmf.runtime.target/2024-03.target
@@ -8,45 +8,45 @@
       <repository id="Eclipse-Shared-License" location="https://download.eclipse.org/cbi/updates/license"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.apache.batik.anim" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.anim.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.xmlgraphics" version="2.10.0.v20241009-1200" />
-      <unit id="org.apache.xmlgraphics.source" version="2.10.0.v20241009-1200" />
-      <repository id="Orbit-4.35.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.35.0"/>
+      <unit id="org.apache.batik.anim" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.anim.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.xmlgraphics" version="2.11.0.v20250506-1400" />
+      <unit id="org.apache.xmlgraphics.source" version="2.11.0.v20250506-1400" />
+      <repository id="Orbit-4.36.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
     </location>
     <!-- End common locations -->
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/releng/org.eclipse.gmf.runtime.target/2024-06.target
+++ b/releng/org.eclipse.gmf.runtime.target/2024-06.target
@@ -8,45 +8,45 @@
       <repository id="Eclipse-Shared-License" location="https://download.eclipse.org/cbi/updates/license"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.apache.batik.anim" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.anim.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.xmlgraphics" version="2.10.0.v20241009-1200" />
-      <unit id="org.apache.xmlgraphics.source" version="2.10.0.v20241009-1200" />
-      <repository id="Orbit-4.35.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.35.0"/>
+      <unit id="org.apache.batik.anim" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.anim.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.xmlgraphics" version="2.11.0.v20250506-1400" />
+      <unit id="org.apache.xmlgraphics.source" version="2.11.0.v20250506-1400" />
+      <repository id="Orbit-4.36.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
     </location>
     <!-- End common locations -->
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/releng/org.eclipse.gmf.runtime.target/2024-09.target
+++ b/releng/org.eclipse.gmf.runtime.target/2024-09.target
@@ -8,45 +8,45 @@
       <repository id="Eclipse-Shared-License" location="https://download.eclipse.org/cbi/updates/license"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.apache.batik.anim" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.anim.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.xmlgraphics" version="2.10.0.v20241009-1200" />
-      <unit id="org.apache.xmlgraphics.source" version="2.10.0.v20241009-1200" />
-      <repository id="Orbit-4.35.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.35.0"/>
+      <unit id="org.apache.batik.anim" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.anim.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.xmlgraphics" version="2.11.0.v20250506-1400" />
+      <unit id="org.apache.xmlgraphics.source" version="2.11.0.v20250506-1400" />
+      <repository id="Orbit-4.36.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
     </location>
     <!-- End common locations -->
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/releng/org.eclipse.gmf.runtime.target/2024-12.target
+++ b/releng/org.eclipse.gmf.runtime.target/2024-12.target
@@ -8,45 +8,45 @@
       <repository id="Eclipse-Shared-License" location="https://download.eclipse.org/cbi/updates/license"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.apache.batik.anim" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.anim.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.xmlgraphics" version="2.10.0.v20241009-1200" />
-      <unit id="org.apache.xmlgraphics.source" version="2.10.0.v20241009-1200" />
-      <repository id="Orbit-4.35.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.35.0"/>
+      <unit id="org.apache.batik.anim" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.anim.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.xmlgraphics" version="2.11.0.v20250506-1400" />
+      <unit id="org.apache.xmlgraphics.source" version="2.11.0.v20250506-1400" />
+      <repository id="Orbit-4.36.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
     </location>
     <!-- End common locations -->
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/releng/org.eclipse.gmf.runtime.target/2025-03.target
+++ b/releng/org.eclipse.gmf.runtime.target/2025-03.target
@@ -8,45 +8,45 @@
       <repository id="Eclipse-Shared-License" location="https://download.eclipse.org/cbi/updates/license"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.apache.batik.anim" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.anim.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.xmlgraphics" version="2.10.0.v20241009-1200" />
-      <unit id="org.apache.xmlgraphics.source" version="2.10.0.v20241009-1200" />
-      <repository id="Orbit-4.35.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.35.0"/>
+      <unit id="org.apache.batik.anim" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.anim.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.xmlgraphics" version="2.11.0.v20250506-1400" />
+      <unit id="org.apache.xmlgraphics.source" version="2.11.0.v20250506-1400" />
+      <repository id="Orbit-4.36.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
     </location>
     <!-- End common locations -->
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/releng/org.eclipse.gmf.runtime.target/2025-06.target
+++ b/releng/org.eclipse.gmf.runtime.target/2025-06.target
@@ -8,45 +8,45 @@
       <repository id="Eclipse-Shared-License" location="https://download.eclipse.org/cbi/updates/license"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.apache.batik.anim" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.anim.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.xmlgraphics" version="2.10.0.v20241009-1200" />
-      <unit id="org.apache.xmlgraphics.source" version="2.10.0.v20241009-1200" />
-      <repository id="Orbit-4.35.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/release/4.35.0"/>
+      <unit id="org.apache.batik.anim" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.anim.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.xmlgraphics" version="2.11.0.v20250506-1400" />
+      <unit id="org.apache.xmlgraphics.source" version="2.11.0.v20250506-1400" />
+      <repository id="Orbit-4.36.0" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/milestone/latest"/>
     </location>
     <!-- End common locations -->
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/releng/org.eclipse.gmf.runtime.target/canary.target
+++ b/releng/org.eclipse.gmf.runtime.target/canary.target
@@ -28,47 +28,44 @@
       <repository id="UML2-LastSuccessful" location="https://download.eclipse.org/modeling/mdt/uml2/updates/interim/latest"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.apache.batik.anim" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.anim.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.awt.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.bridge.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.codec.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.constants.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.css.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.dom.svg.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.ext.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.gvt.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.i18n.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.parser.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.script.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.shared.resources.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.svggen.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.transcoder.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.util.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.batik.xml.source" version="1.18.0.v20241009-1200"/>
-      <unit id="org.apache.xmlgraphics" version="2.10.0.v20241009-1200" />
-      <unit id="org.apache.xmlgraphics.source" version="2.10.0.v20241009-1200" />
-      <!--<unit id="org.apache.commons.commons-io" version="0.0.0"/>
-      <unit id="org.apache.commons.commons-logging" version="0.0.0"/>
-      <unit id="org.hamcrest" version="2.2.0"/>-->
+      <unit id="org.apache.batik.anim" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.anim.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.awt.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.bridge.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.codec.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.constants.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.css.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.dom.svg.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.ext.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.gvt.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.i18n.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.parser.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.script.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.shared.resources.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.svggen.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.transcoder.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.util.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.batik.xml.source" version="1.19.0.v20250506-1400"/>
+      <unit id="org.apache.xmlgraphics" version="2.11.0.v20250506-1400" />
+      <unit id="org.apache.xmlgraphics.source" version="2.11.0.v20250506-1400" />
       <repository id="Orbit-latest-I" location="https://download.eclipse.org/tools/orbit/simrel/orbit-aggregation/nightly"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">


### PR DESCRIPTION
This reverts commit eed618da461eed22986c189fece92f8946072558.

See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/discussions/3219

Bug: https://github.com/eclipse-gmf-runtime/gmf-runtime/issues/87
Signed-off-by: Pierre-Charles David <pierre-charles.david@obeo.fr>
